### PR TITLE
README.md: Use 'written' instead of 'wrote'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 serverstf
 =========
 
-Web-based TF2 server browser wrote in Python using Django.
+Web-based TF2 server browser written in Python using Django.
 
 ### Requirements
 


### PR DESCRIPTION
The use of written instead of wrote is important in modern english.
It has several implications:
- User having to write written instead of wrote
- The case where the user has to write instead of writting
- Any other case

Therefore it is best to use written instead of wrote to avoid
cases where it would have been written as wrote.
