### PR TITLE
Add Versus Saxton Hale tag

### DIFF
--- a/serverstf/tags/mode.py
+++ b/serverstf/tags/mode.py
@@ -57,3 +57,14 @@ def sb(info, players, rules, tags):
     return ("tf2" in tags
             and "mode:arena" in tags
             and info["map"].lower().startswith("sb_"))
+
+
+@tag("mode:vsh", ["tf2", "mode:arena"])
+def vsh(info, players, rules, tags):
+    """Versus Saxton Hale
+
+    Official thread: http://bit.ly/1jZTvex
+    """
+    return ("tf2" in tags
+            and "mode:arena" in tags
+            and info["map"].lower().startswith("vsh_"))

--- a/serverstf/tags/mode.py
+++ b/serverstf/tags/mode.py
@@ -61,9 +61,9 @@ def sb(info, players, rules, tags):
 
 @tag("mode:vsh", ["tf2", "mode:arena"])
 def vsh(info, players, rules, tags):
-    """Versus Saxton Hale
+    """Versus Saxton Hale.
 
-    Official thread: http://bit.ly/1jZTvex
+    Official thread: https://forums.alliedmods.net/showthread.php?t=244209
     """
     return ("tf2" in tags
             and "mode:arena" in tags


### PR DESCRIPTION
http://bit.ly/1jZTvex <- I included the link in the docstring as well :package: 

Versus saxton hale mod.

_Technically_ is `mode:arena`, though most of the maps have a single capture point...

Keep up the awesome work you are doing for svtf!